### PR TITLE
Corrected messaging to warn against less- to more-strictly aligned

### DIFF
--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -679,10 +679,10 @@ declare_clippy_lint! {
     "cast to the same type, e.g. `x as i32` where `x: i32`"
 }
 
-/// **What it does:** Checks for casts from a more-strictly-aligned pointer to a
-/// less-strictly-aligned pointer
+/// **What it does:** Checks for casts from a less-strictly-aligned pointer to a
+/// more-strictly-aligned pointer
 ///
-/// **Why is this bad?** Dereferencing the resulting pointer is undefined
+/// **Why is this bad?** Dereferencing the resulting pointer may be undefined
 /// behavior.
 ///
 /// **Known problems:** None.
@@ -695,7 +695,7 @@ declare_clippy_lint! {
 declare_clippy_lint! {
     pub CAST_PTR_ALIGNMENT,
     correctness,
-    "cast from a pointer to a less-strictly-aligned pointer"
+    "cast from a pointer to a more-strictly-aligned pointer"
 }
 
 /// Returns the size in bits of an integral type.
@@ -986,7 +986,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CastPass {
                         cx,
                         CAST_PTR_ALIGNMENT,
                         expr.span,
-                        &format!("casting from `{}` to a less-strictly-aligned pointer (`{}`)", cast_from, cast_to)
+                        &format!("casting from `{}` to a more-strictly-aligned pointer (`{}`)", cast_from, cast_to)
                     );
                 }
             }

--- a/tests/ui/cast_alignment.stderr
+++ b/tests/ui/cast_alignment.stderr
@@ -1,4 +1,4 @@
-error: casting from `*const u8` to a less-strictly-aligned pointer (`*const u16`)
+error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`)
  --> $DIR/cast_alignment.rs:9:5
   |
 9 |     (&1u8 as *const u8) as *const u16;
@@ -6,7 +6,7 @@ error: casting from `*const u8` to a less-strictly-aligned pointer (`*const u16`
   |
   = note: `-D cast-ptr-alignment` implied by `-D warnings`
 
-error: casting from `*mut u8` to a less-strictly-aligned pointer (`*mut u16`)
+error: casting from `*mut u8` to a more-strictly-aligned pointer (`*mut u16`)
   --> $DIR/cast_alignment.rs:10:5
    |
 10 |     (&mut 1u8 as *mut u8) as *mut u16;


### PR DESCRIPTION
types, rather than the other way around.  No logic changes required.